### PR TITLE
Add ability to set s3 ProxyHost and ProxyPort 

### DIFF
--- a/cascading-local-s3/src/main/java/cascading/local/tap/aws/s3/S3Tap.java
+++ b/cascading-local-s3/src/main/java/cascading/local/tap/aws/s3/S3Tap.java
@@ -49,6 +49,8 @@ import cascading.tuple.TupleEntrySchemeCollector;
 import cascading.tuple.TupleEntrySchemeIterator;
 import cascading.util.CloseableIterator;
 import cascading.util.Util;
+import com.amazonaws.ClientConfiguration;
+import com.amazonaws.Protocol;
 import com.amazonaws.client.builder.AwsClientBuilder;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
@@ -923,6 +925,19 @@ public class S3Tap extends Tap<Properties, InputStream, OutputStream> implements
       {
       String endpoint = properties.getProperty( S3TapProps.S3_ENDPOINT );
       String region = properties.getProperty( S3TapProps.S3_REGION, "us-east-1" );
+
+      if( properties.containsKey( S3TapProps.S3_PROXY_HOST ) )
+        {
+
+        ClientConfiguration config = new ClientConfiguration();
+        config.setProtocol(Protocol.HTTPS);
+        config.setProxyHost( properties.getProperty( S3TapProps.S3_PROXY_HOST ) );
+
+        if(  properties.containsKey( S3TapProps.S3_PROXY_PORT ) )
+          config.setProxyPort( Integer.valueOf( properties.getProperty( S3TapProps.S3_PROXY_PORT ) ) );
+
+        standard.withClientConfiguration(config);
+        }
 
       if( endpoint != null )
         standard.withEndpointConfiguration( new AwsClientBuilder.EndpointConfiguration( endpoint, region ) );

--- a/cascading-local-s3/src/main/java/cascading/local/tap/aws/s3/S3Tap.java
+++ b/cascading-local-s3/src/main/java/cascading/local/tap/aws/s3/S3Tap.java
@@ -59,6 +59,7 @@ import com.amazonaws.services.s3.model.S3ObjectSummary;
 import com.amazonaws.services.s3.transfer.TransferManager;
 import com.amazonaws.services.s3.transfer.TransferManagerBuilder;
 import com.amazonaws.services.s3.transfer.Upload;
+import com.amazonaws.services.s3.transfer.model.UploadResult;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -1177,14 +1178,22 @@ public class S3Tap extends Tap<Properties, InputStream, OutputStream> implements
 
         try
           {
-          if( LOG.isDebugEnabled() )
-            LOG.debug( "completing upload: {}", getIdentifier() );
 
-          upload.waitForUploadResult();
+          UploadResult uploadResult = upload.waitForUploadResult();
+          if(uploadResult!= null)
+            {
+            String uploadedS3Filename = uploadResult.getKey();
+            LOG.info("File uploaded with key: " + uploadedS3Filename);
+            transferManager.shutdownNow();
+            }
           }
         catch( InterruptedException exception )
           {
           // ignore
+          }
+        finally
+          {
+            transferManager.shutdownNow();
           }
         }
       };

--- a/cascading-local-s3/src/main/java/cascading/local/tap/aws/s3/S3TapProps.java
+++ b/cascading-local-s3/src/main/java/cascading/local/tap/aws/s3/S3TapProps.java
@@ -36,6 +36,11 @@ public class S3TapProps extends Props
   public static final String S3_REGION = "cascading.tap.aws.s3.region";
   /** Field S3_PATH_STYLE_ACCESS */
   public static final String S3_PATH_STYLE_ACCESS = "cascading.tap.aws.s3.path_style_access";
+  /** Field S3_PROXY_HOST */
+  public static final String S3_PROXY_HOST = "cascading.tap.aws.s3.proxy.host";
+  /** Field S3_PROXY_PORT */
+  public static final String S3_PROXY_PORT = "cascading.tap.aws.s3.proxy.port";
+
 
   /** Field endpoint */
   String endpoint;
@@ -43,6 +48,10 @@ public class S3TapProps extends Props
   String region;
   /** pathStyleAccess */
   boolean pathStyleAccess = false;
+  /** Field proxyHost */
+  String proxyHost;
+  /** Field proxyPort */
+  int proxyPort;
 
   /**
    * Constructor S3TapProps creates a new S3TapProps instance.
@@ -123,6 +132,50 @@ public class S3TapProps extends Props
     return this;
     }
 
+  /**
+   * Method getProxyHost returns the optional S3 proxy host of this S3TapProps object.
+   *
+   * @return the S3 proxy host (type String) of this S3TapProps object.
+   */
+  public String getProxyHost()
+    {
+      return proxyHost;
+    }
+
+  /**
+   * Method setProxyHost sets the optional proxy host this S3TapProps object will connect through.
+   *
+   * @param proxyHost the proxy host this S3TapProps object will connect through .
+   * @return S3TapProps
+   */
+  public S3TapProps setProxyHost(String proxyHost)
+    {
+      this.proxyHost = proxyHost;
+
+      return this;
+    }
+
+  /**
+   * Method getProxyPort returns the optional S3 proxy port this S3TapProps object will connect through
+   *
+   * @return the S3 proxy port (type int) this S3TapProps object will connect through.
+   */
+  public int getProxyPort() {
+      return proxyPort;
+    }
+
+  /**
+   * Method setProxyPort sets the optional proxy port this S3TapProps object will connect through.
+   *
+   * @param proxyPort the proxy host this S3TapProps object will connect through .
+   * @return S3TapProps
+   */
+  public S3TapProps setProxyPort(int proxyPort) {
+      this.proxyPort = proxyPort;
+
+      return this;
+    }
+
   @Override
   protected void addPropertiesTo( Properties properties )
     {
@@ -134,5 +187,11 @@ public class S3TapProps extends Props
 
     if( pathStyleAccess )
       properties.setProperty( S3_PATH_STYLE_ACCESS, "true" );
+
+    if( proxyHost != null )
+      properties.setProperty( S3_PROXY_HOST, proxyHost);
+
+    if( proxyPort > 0)
+      properties.setProperty( S3_PROXY_PORT, String.valueOf(proxyPort));
     }
   }


### PR DESCRIPTION
Adding ability to set s3 proxy host and s3 proxy port when configuring s3 client.
Also, fix issue when complete uploading objects to S3 bucket, the thread keeps running in the background and doesn't end upon completion by explicitly calling transferManager.shutdownNow() when closing the s3Tap

