### PR TITLE
Add ability to set s3 ProxyHost and ProxyPort

### DIFF
--- a/cascading-local-s3/src/main/java/cascading/local/tap/aws/s3/S3Tap.java
+++ b/cascading-local-s3/src/main/java/cascading/local/tap/aws/s3/S3Tap.java
@@ -36,6 +36,7 @@ import java.util.function.Predicate;
 import java.util.regex.Pattern;
 
 import cascading.flow.FlowProcess;
+import cascading.property.PropertyUtil;
 import cascading.scheme.FileFormat;
 import cascading.scheme.Scheme;
 import cascading.tap.SinkMode;
@@ -49,6 +50,7 @@ import cascading.tuple.TupleEntrySchemeCollector;
 import cascading.tuple.TupleEntrySchemeIterator;
 import cascading.util.CloseableIterator;
 import cascading.util.Util;
+import com.amazonaws.ClientConfiguration;
 import com.amazonaws.client.builder.AwsClientBuilder;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
@@ -924,6 +926,15 @@ public class S3Tap extends Tap<Properties, InputStream, OutputStream> implements
       {
       String endpoint = properties.getProperty( S3TapProps.S3_ENDPOINT );
       String region = properties.getProperty( S3TapProps.S3_REGION, "us-east-1" );
+
+      if( properties.containsKey( S3TapProps.S3_PROXY_HOST ) )
+        {
+        ClientConfiguration config = new ClientConfiguration()
+          .withProxyHost( properties.getProperty( S3TapProps.S3_PROXY_HOST ) )
+          .withProxyPort( PropertyUtil.getIntProperty( properties, S3TapProps.S3_PROXY_PORT, -1 ) );
+
+        standard.withClientConfiguration( config );
+        }
 
       if( endpoint != null )
         standard.withEndpointConfiguration( new AwsClientBuilder.EndpointConfiguration( endpoint, region ) );

--- a/cascading-local-s3/src/main/java/cascading/local/tap/aws/s3/S3Tap.java
+++ b/cascading-local-s3/src/main/java/cascading/local/tap/aws/s3/S3Tap.java
@@ -57,6 +57,7 @@ import com.amazonaws.services.s3.model.S3ObjectSummary;
 import com.amazonaws.services.s3.transfer.TransferManager;
 import com.amazonaws.services.s3.transfer.TransferManagerBuilder;
 import com.amazonaws.services.s3.transfer.Upload;
+import com.amazonaws.services.s3.transfer.model.UploadResult;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -1162,14 +1163,21 @@ public class S3Tap extends Tap<Properties, InputStream, OutputStream> implements
 
         try
           {
-          if( LOG.isDebugEnabled() )
-            LOG.debug( "completing upload: {}", getIdentifier() );
+          UploadResult uploadResult = upload.waitForUploadResult();
 
-          upload.waitForUploadResult();
+          if( uploadResult != null )
+            {
+            if( LOG.isDebugEnabled() )
+              LOG.debug( "completed upload: {}, with key: {}", getIdentifier(), uploadResult.getKey() );
+            }
           }
         catch( InterruptedException exception )
           {
           // ignore
+          }
+        finally
+          {
+          transferManager.shutdownNow();
           }
         }
       };

--- a/cascading-local-s3/src/main/java/cascading/local/tap/aws/s3/S3Tap.java
+++ b/cascading-local-s3/src/main/java/cascading/local/tap/aws/s3/S3Tap.java
@@ -1188,7 +1188,7 @@ public class S3Tap extends Tap<Properties, InputStream, OutputStream> implements
           }
         finally
           {
-          transferManager.shutdownNow();
+          transferManager.shutdownNow(false);
           }
         }
       };

--- a/cascading-local-s3/src/main/java/cascading/local/tap/aws/s3/S3TapProps.java
+++ b/cascading-local-s3/src/main/java/cascading/local/tap/aws/s3/S3TapProps.java
@@ -36,6 +36,10 @@ public class S3TapProps extends Props
   public static final String S3_REGION = "cascading.tap.aws.s3.region";
   /** Field S3_PATH_STYLE_ACCESS */
   public static final String S3_PATH_STYLE_ACCESS = "cascading.tap.aws.s3.path_style_access";
+  /** Field S3_PROXY_HOST */
+  public static final String S3_PROXY_HOST = "cascading.tap.aws.s3.proxy.host";
+  /** Field S3_PROXY_PORT */
+  public static final String S3_PROXY_PORT = "cascading.tap.aws.s3.proxy.port";
 
   /** Field endpoint */
   String endpoint;
@@ -43,6 +47,10 @@ public class S3TapProps extends Props
   String region;
   /** pathStyleAccess */
   boolean pathStyleAccess = false;
+  /** Field proxyHost */
+  String proxyHost;
+  /** Field proxyPort */
+  int proxyPort;
 
   /**
    * Constructor S3TapProps creates a new S3TapProps instance.
@@ -123,6 +131,52 @@ public class S3TapProps extends Props
     return this;
     }
 
+  /**
+   * Method getProxyHost returns the optional S3 proxy host of this S3TapProps object.
+   *
+   * @return the S3 proxy host (type String) of this S3TapProps object.
+   */
+  public String getProxyHost()
+    {
+    return proxyHost;
+    }
+
+  /**
+   * Method setProxyHost sets the optional proxy host this S3TapProps object will connect through.
+   *
+   * @param proxyHost the proxy host this S3TapProps object will connect through .
+   * @return S3TapProps
+   */
+  public S3TapProps setProxyHost( String proxyHost )
+    {
+    this.proxyHost = proxyHost;
+
+    return this;
+    }
+
+  /**
+   * Method getProxyPort returns the optional S3 proxy port this S3TapProps object will connect through
+   *
+   * @return the S3 proxy port (type int) this S3TapProps object will connect through.
+   */
+  public int getProxyPort()
+    {
+    return proxyPort;
+    }
+
+  /**
+   * Method setProxyPort sets the optional proxy port this S3TapProps object will connect through.
+   *
+   * @param proxyPort the proxy host this S3TapProps object will connect through .
+   * @return S3TapProps
+   */
+  public S3TapProps setProxyPort( int proxyPort )
+    {
+    this.proxyPort = proxyPort;
+
+    return this;
+    }
+
   @Override
   protected void addPropertiesTo( Properties properties )
     {
@@ -134,5 +188,11 @@ public class S3TapProps extends Props
 
     if( pathStyleAccess )
       properties.setProperty( S3_PATH_STYLE_ACCESS, "true" );
+
+    if( proxyHost != null )
+      properties.setProperty( S3_PROXY_HOST, proxyHost );
+
+    if( proxyPort > 0 )
+      properties.setProperty( S3_PROXY_PORT, String.valueOf( proxyPort ) );
     }
   }

--- a/etc/dependencyVersions.gradle
+++ b/etc/dependencyVersions.gradle
@@ -22,7 +22,7 @@ configurations.all {
   resolutionStrategy.cacheDynamicVersionsFor 5, 'minutes'
 }
 
-ext.cascadingVersion = '4.0.0-wip-46'
+ext.cascadingVersion = '4.0.0-wip-61'
 
 ext.awsVersion = '1.11.271'
 ext.awsS3Version = awsVersion


### PR DESCRIPTION
Adding ability to set s3 proxy host and s3 proxy port when configuring s3 client.
Also, fix issue when complete uploading objects to S3 bucket, the thread keeps running in the background and doesn't end upon completion by explicitly calling transferManager.shutdownNow() when closing the s3Tap

====
Note: This is a re-created branch based on the feedback from @cwensel in https://github.com/cwensel/cascading-local/pull/2#issuecomment-442310435

@cwensel fyi, somehow the original PR got closed when I deleted my old branch in order to replace with yours so I open a new PR. I have the branch name stay the same as before.